### PR TITLE
Change variable names to avoid hitting Puppet 3.4 future parser bug

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -80,26 +80,26 @@ define createrepo (
     case $::osfamily {
         'RedHat':{
             if $changelog_limit =~ /^\d+$/ {
-                $_arg_changelog = " --changelog-limit ${changelog_limit}"
+                $arg_changelog = " --changelog-limit ${changelog_limit}"
             } else {
-                $_arg_changelog = ''
+                $arg_changelog = ''
             }
 
             if $checksum_type {
-                $_arg_checksum = " --checksum ${checksum_type}"
+                $arg_checksum = " --checksum ${checksum_type}"
             } else {
-                $_arg_checksum = ''
+                $arg_checksum = ''
             }
         }
         default:{
             # createrepo distributed with some OS don't have these options
-            $_arg_checksum  = ''
-            $_arg_changelog = ''
+            $arg_checksum  = ''
+            $arg_changelog = ''
         }
     }
 
     $cmd = '/usr/bin/createrepo'
-    $arg = "--cachedir ${repo_cache_dir}${_arg_changelog}${_arg_checksum}"
+    $arg = "--cachedir ${repo_cache_dir}${arg_changelog}${arg_checksum}"
     $createrepo_create = "${cmd} ${arg} --database ${repository_dir}"
     $createrepo_update = "${cmd} ${arg} --update ${repository_dir}"
 


### PR DESCRIPTION
This is a puppet bug as the variables are valid as per [the docs](http://docs.puppetlabs.com/puppet/latest/reference/lang_reserved.html#variables), but it's an easy work around to change the variable names. 

Completely understand if you don't want to accept the change.
