### PR TITLE
Remove upper bound on puppetlabs/stdlib requirement

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "palli-createrepo",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "author": "Pall Valmundsson",
   "summary": "Manages creation of yum repositories",
   "license": "GPL-3.0+",
@@ -39,7 +39,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">=4.0.0 <5.0.0"
+      "version_requirement": ">=4.0.0"
     }
   ]
 }


### PR DESCRIPTION
With stdlib 6.0.0 out, there appears to be no reason to have such a tight bound on this, as it has no negative effect on the module (the breaking changes are mostly around supported puppet versions) but is restricting the ability of the PMT to satisfy version requirements among modules.

This will also require a new release to the forge.