### PR TITLE
Trigger repo update only on changes.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -283,11 +283,12 @@ define createrepo (
     validate_bool($enable_update)
     if $enable_update {
         exec { "update-createrepo-${name}":
-            command => $real_update_file_path,
-            user    => $repo_owner,
-            group   => $repo_group,
-            timeout => $timeout,
-            require => [Exec["createrepo-${name}"], File[$real_update_file_path]],
+            command     => $real_update_file_path,
+            user        => $repo_owner,
+            group       => $repo_group,
+            timeout     => $timeout,
+            refreshonly => true,
+            require     => [Exec["createrepo-${name}"], File[$real_update_file_path]],
         }
     }
 }


### PR DESCRIPTION
If enabled, the update exec resource is executed on every puppet run. By adding `refreshonly => true`, the exec will only be triggered on changes to the resources defined in require.

This makes puppet runs report no changes if there are none. Otherwise the whole repodata directory of a repository will get overwritten with the same data over and over again.